### PR TITLE
Updates to get the latest version automatically

### DIFF
--- a/hook-fcos.sh
+++ b/hook-fcos.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 #set -e
- 
+
 vmid="$1"
 phase="$2"
 
 # global vars
 COREOS_TMPLT=/opt/fcos-tmplt.yaml
 COREOS_FILES_PATH=/etc/pve/geco-pve/coreos
-YQ="/usr/local/bin/yq read --exitStatus --printMode v --stripComments --"
+YQ="yq read --exitStatus --printMode v --stripComments --"
 
 # ==================================================================================================================================================================
 # functions()
@@ -27,9 +27,6 @@ setup_fcoreosct()
         chmod 755 /usr/local/bin/fcos-ct
 }
 setup_fcoreosct
-
-if [[ ! -f $(which jq) ]]; then apt install jq -y; fi
-if [[ ! -f $(which yq) ]]; then apt install yq -y; fi
 
 # ==================================================================================================================================================================
 # main()

--- a/hook-fcos.sh
+++ b/hook-fcos.sh
@@ -28,18 +28,8 @@ setup_fcoreosct()
 }
 setup_fcoreosct
 
-setup_yq()
-{
-        local VER=3.4.1
-
-        [[ -x /usr/bin/wget ]]&& download_command="wget --quiet --show-progress --output-document"  || download_command="curl --location --output"
-        [[ -x /usr/local/bin/yq ]]&& [[ "x$(/usr/local/bin/yq --version | awk '{print $NF}')" == "x${VER}" ]]&& return 0
-        echo "Setup yaml parser tools yq..."
-        rm -f /usr/local/bin/yq
-        ${download_command} /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${VER}/yq_linux_amd64
-        chmod 755 /usr/local/bin/yq
-}
-setup_yq
+if [[ ! -f $(which jq) ]]; then apt install jq -y; fi
+if [[ ! -f $(which yq) ]]; then apt install yq -y; fi
 
 # ==================================================================================================================================================================
 # main()

--- a/hook-fcos.sh
+++ b/hook-fcos.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 #set -e
-
+ 
 vmid="$1"
 phase="$2"
 
 # global vars
 COREOS_TMPLT=/opt/fcos-tmplt.yaml
 COREOS_FILES_PATH=/etc/pve/geco-pve/coreos
-YQ="yq read --exitStatus --printMode v --stripComments --"
+YQ="/usr/local/bin/yq read --exitStatus --printMode v --stripComments --"
 
 # ==================================================================================================================================================================
 # functions()
@@ -27,6 +27,19 @@ setup_fcoreosct()
         chmod 755 /usr/local/bin/fcos-ct
 }
 setup_fcoreosct
+
+setup_yq()
+{
+        local VER=3.4.1
+
+        [[ -x /usr/bin/wget ]]&& download_command="wget --quiet --show-progress --output-document"  || download_command="curl --location --output"
+        [[ -x /usr/local/bin/yq ]]&& [[ "x$(/usr/local/bin/yq --version | awk '{print $NF}')" == "x${VER}" ]]&& return 0
+        echo "Setup yaml parser tools yq..."
+        rm -f /usr/local/bin/yq
+        ${download_command} /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${VER}/yq_linux_amd64
+        chmod 755 /usr/local/bin/yq
+}
+setup_yq
 
 # ==================================================================================================================================================================
 # main()

--- a/vmsetup.sh
+++ b/vmsetup.sh
@@ -10,6 +10,11 @@ set -e
 export LANG=C
 export LC_ALL=C
 
+# Install dependencies
+if [[ ! -f $(which jq) ]]; then apt install jq -y; fi
+if [[ ! -f $(which yq) ]]; then apt install yq -y; fi
+
+ 
 # template vm vars
 TEMPLATE_VMID="900"
 TEMPLATE_VMSTORAGE="local"

--- a/vmsetup.sh
+++ b/vmsetup.sh
@@ -20,7 +20,8 @@ TEMPLATE_IGNITION="fcos-base-tmplt.yaml"
 
 # fcos version
 STREAMS=stable
-VERSION=32.20201018.3.0
+# Get the latest version
+VERSION=$(curl -s "https://builds.coreos.fedoraproject.org/streams/stable.json"| grep -A 10 "x86_64" | grep -A 10 "qemu" | grep "release" -m 1 | sed -E 's/.*"release": *"([^"]+)".*/\1/')
 PLATEFORM=qemu
 BASEURL=https://builds.coreos.fedoraproject.org
 

--- a/vmsetup.sh
+++ b/vmsetup.sh
@@ -21,7 +21,7 @@ TEMPLATE_IGNITION="fcos-base-tmplt.yaml"
 # fcos version
 STREAMS=stable
 # Get the latest version
-VERSION=$(curl -s "https://builds.coreos.fedoraproject.org/streams/stable.json"| grep -A 10 "x86_64" | grep -A 10 "qemu" | grep "release" -m 1 | sed -E 's/.*"release": *"([^"]+)".*/\1/')
+VERSION=$(curl -s "https://builds.coreos.fedoraproject.org/streams/stable.json"| jq '.architectures.x86_64.artifacts.qemu.release')
 PLATEFORM=qemu
 BASEURL=https://builds.coreos.fedoraproject.org
 

--- a/vmsetup.sh
+++ b/vmsetup.sh
@@ -12,8 +12,6 @@ export LC_ALL=C
 
 # Install dependencies
 if [[ ! -f $(which jq) ]]; then apt install jq -y; fi
-if [[ ! -f $(which yq) ]]; then apt install yq -y; fi
-
  
 # template vm vars
 TEMPLATE_VMID="900"


### PR DESCRIPTION
hook-fcos.sh now installs yq and jq from apt if it is not present on the system already. vmsetup.sh changed to get the latest version of the selected platform and stream, change the PLATFORM or STREAM variable accordingly and it will use whatever is specified if it exists.